### PR TITLE
Add support for splitting on Switch Palaces

### DIFF
--- a/LiveSplit.SMW/LiveSplit.SMW.asl
+++ b/LiveSplit.SMW/LiveSplit.SMW.asl
@@ -8,6 +8,8 @@ startup
 	settings.SetToolTip("levels", "Split on crossing goal tapes and activating keyholes");
 	settings.Add("bosses", true, "Boss Levels");
 	settings.SetToolTip("bosses", "Split on boss fanfare");
+	settings.Add("switchPalaces", false, "Switch Palaces");
+	settings.SetToolTip("switchPalaces", "Split on completing a switch palace");
 }
 
 init
@@ -61,6 +63,10 @@ init
 		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x1ED2) { Name = "fileSelect" },
 		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x906) { Name = "fanfare" },
 		new MemoryWatcher<short>((IntPtr)memoryOffset + 0x1434) { Name = "keyholeTimer" },
+		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x1f28) { Name = "yellowSwitch" },
+		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x1f27) { Name = "greenSwitch" },
+		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x1f29) { Name = "blueSwitch" },
+		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x1f2a) { Name = "redSwitch" },
 		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x13C6) { Name = "bossDefeat" },
 		new MemoryWatcher<byte>((IntPtr)memoryOffset + 0x190D) { Name = "peach" },
 	};
@@ -85,8 +91,13 @@ split
 {
 	var goalExit = settings["levels"] && vars.watchers["fanfare"].Old == 0 && vars.watchers["fanfare"].Current == 1 && vars.watchers["bossDefeat"].Current == 0;
 	var keyExit = settings["levels"] && vars.watchers["keyholeTimer"].Old == 0 && vars.watchers["keyholeTimer"].Current == 0x0030;
+	var yellowPalace = settings["switchPalaces"] && vars.watchers["yellowSwitch"].Old == 0 && vars.watchers["yellowSwitch"].Current == 1;
+	var greenPalace = settings["switchPalaces"] && vars.watchers["greenSwitch"].Old == 0 && vars.watchers["greenSwitch"].Current == 1;
+	var bluePalace = settings["switchPalaces"] && vars.watchers["blueSwitch"].Old == 0 && vars.watchers["blueSwitch"].Current == 1;
+	var redPalace = settings["switchPalaces"] && vars.watchers["redSwitch"].Old == 0 && vars.watchers["redSwitch"].Current == 1;
+	var switchPalaceExit = yellowPalace || greenPalace || bluePalace || redPalace;
 	var bossExit = settings["bosses"] && vars.watchers["fanfare"].Old == 0 && vars.watchers["fanfare"].Current == 1 && vars.watchers["bossDefeat"].Current == 1;
 	var bowserDefeated = settings["bosses"] && vars.watchers["peach"].Old == 0 && vars.watchers["peach"].Current == 1;
 
-	return goalExit || keyExit || bossExit || bowserDefeated;
+	return goalExit || keyExit || switchPalaceExit || bossExit || bowserDefeated;
 }


### PR DESCRIPTION
None of the values used for either standard stages or boss stages change when you finish a Switch Palace. Instead, the only value I've found so far that changes is the global flag for whether the switch has been pressed.

I set it off by default.