### PR TITLE
Fix: Ether and Bombos Tablet splitting

### DIFF
--- a/LiveSplit.ALttP/LiveSplit.ALttP.asl
+++ b/LiveSplit.ALttP/LiveSplit.ALttP.asl
@@ -96,8 +96,8 @@ split
 	var swordUp = vars.watchers["linkState"].Changed && vars.watchers["linkState"].Current == 0x24;
 
 	var escape = settings["escape"] && vars.watchers["yPos"].Current > vars.watchers["yPos"].Old && vars.watchers["yPos"].Current == 0x0218 && vars.watchers["mapTile"].Current == 0x36; //old.yPos == 0x01 && current.yPos == 0x02 && current.world == 0x0A && current.mapTile == 0x36;
-	var pendant = settings["pendants"] && swordUp && (vars.lastItem == 0x37 || vars.lastItem == 0x39 || vars.lastItem == 0x38);
-	var crystal = settings["crystals"] && swordUp && vars.lastItem == 0x20;
+	var pendant = settings["pendants"] && swordUp && vars.watchers["world"].Current == 0x0A && (vars.lastItem == 0x37 || vars.lastItem == 0x39 || vars.lastItem == 0x38);
+	var crystal = settings["crystals"] && swordUp && vars.watchers["world"].Current == 0x0A && vars.lastItem == 0x20;
 	var masterSword = settings["masterSword"] && vars.watchers["linkState"].Changed && vars.watchers["linkState"].Current == 0x17 && vars.watchers["world"].Current == 0x01;
 	var agahnim1 = settings["agahnim1"] && swordUp && vars.watchers["mapTile"].Current == 0x60;
 	var agahnim2 = settings["agahnim2"] && vars.watchers["linkState"].Old == 0x1D && vars.watchers["linkState"].Current == 0 && vars.watchers["mapTile"].Current == 0x27;


### PR DESCRIPTION
Because Ether and Bombos Tablet trigger "swordUp", having defeated any dungeon and immediately reading those tablets caused a split if the corresponding setting (pendants or crystals) was set.
This is not a huge deal in NMG Vanilla ALttP since those tablets are routed in differently; but in ALttP Rando it is common practice to read said tablets after clearing nearby dungeons (ToH and SP in particular).
The proposed change adds a check for the world we are currently in to "pendant" and "crystal" in the split function.
The value 0x0A represents the underworld (including all dungeons).
I did not test full functionality but killing Argghus or Moldorm still results in a split while reading the tablets after those does not; so it should be working as intended.