### PR TITLE
[PkmnRed] Add support for GSR r717

### DIFF
--- a/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
+++ b/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
@@ -1,6 +1,7 @@
 state("gambatte") {}
 state("gambatte_qt") {}
 state("gambatte_qt_nonpsr") {}
+state("gambatte_speedrun") {}
 
 startup
 {


### PR DESCRIPTION
GSR r717 changed the defualt emulator name to "gambatte_speedrun"

https://github.com/pokemon-speedrunning/gambatte-speedrun/releases/tag/r717