### PR TITLE
Add ALttP BizHawk 2.6.0 Compatibility

### DIFF
--- a/LiveSplit.ALttP/LiveSplit.ALttP.asl
+++ b/LiveSplit.ALttP/LiveSplit.ALttP.asl
@@ -28,9 +28,10 @@ init {
         { 131543040, 0xA9BD5C },    // bsnes v110
         { 51924992, 0xA9DD5C },     // bsnes v111
         { 52056064, 0xAAED7C },     // bsnes v112
-        { 7061504, 0x36F11500240 }, // BizHawk 2.3
+        { 7061504, 0x36F11500240 }, // BizHawk 2.3.0
         { 7249920, 0x36F11500240 }, // BizHawk 2.3.1
         { 6938624, 0x36F11500240 }, // BizHawk 2.3.2
+        { 4538368, 0x36F05F94040 }, // BizHawk 2.6.0
     };
 
     long memoryOffset;

--- a/LiveSplit.ALttP/README.md
+++ b/LiveSplit.ALttP/README.md
@@ -5,7 +5,7 @@ This is a [LiveSplit](http://livesplit.github.io) [ASL](https://github.com/LiveS
 - bsnes v107+
 - higan v106
 - Snes9x(-rr) 1.60
-- BizHawk 2.3+ (w/ bsnes core)
+- BizHawk 2.3.x, 2.6.x (w/ bsnes core)
 
 ## Features
 - Automatically start the timer when you select a file


### PR DESCRIPTION
The current README claim of 2.3+ is inaccurate, as at some point the memory offset changed after 2.3.2. I added a line for 2.6.0 (latest version to date) compatibility, tested on my machine using the latest Livesplit/BizHawk.