### PR TITLE
Pokémon Red update

### DIFF
--- a/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
+++ b/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
@@ -13,7 +13,7 @@ startup {
     settings.Add("nidoran", true, "Catch 2nd Pokemon (Nidoran/Spearow)");
     settings.Add("route3_bc", false, "Route 3 (BC3)");
     settings.Add("hideoutGiovanni", false, "Hideout (Giovanni)");
-    settings.Add("silphGiovanni", true, "Silph Co. (Giovanni)");
+    settings.Add("silphGiovanni", false, "Silph Co. (Giovanni)");
     settings.Add("nuggetBridge", true, "Nugget Bridge (Rocket)");
     settings.Add("gym1", true, "Pewter Gym (Brock)");
     settings.Add("gym2", true, "Cerulean Gym (Misty)");
@@ -35,7 +35,7 @@ startup {
     settings.Add("route3_sv", false, "Route 3 (Save)");
     settings.Add("enterMtMoon", true, "Enter Mt. Moon");
     settings.Add("exitMtMoon", true, "Exit Mt. Moon");
-    settings.Add("exitVictoryRoad", true, "Exit Victory Road");
+    settings.Add("exitVictoryRoad", false, "Exit Victory Road");
     settings.Add("hm02", true, "Obtain HM02");
     settings.Add("flute", true, "Obtain Poké Flute");
     settings.Add("hof", true, "HoF Fade Out");

--- a/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
+++ b/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
@@ -12,6 +12,7 @@ startup {
     settings.CurrentDefaultParent = "battles";
     settings.Add("nidoran", true, "Catch 2nd Pokemon (Nidoran/Spearow)");
     settings.Add("route3_bc", false, "Route 3 (BC3)");
+    settings.Add("hideoutGiovanni", false, "Hideout (Giovanni)");
     settings.Add("silphGiovanni", true, "Silph Co. (Giovanni)");
     settings.Add("nuggetBridge", true, "Nugget Bridge (Rocket)");
     settings.Add("gym1", true, "Pewter Gym (Brock)");
@@ -106,6 +107,7 @@ startup {
             { "nidoran", new Dictionary<string, uint> { { "partyCount", 2u }, { "stack", 0x03AEu } } },
             { "route3_bc", new Dictionary<string, uint> { { "opponentName", 0x7F869481 }, { "opponentTrainerNo", 6u }, { "enemyPkmn", 0u }, {"stack", 0x03AEu } } },
             { "nuggetBridge", new Dictionary<string, uint> { { "opponentName", 0x8A828E91 }, { "mapIndex", 0x23u }, { "enemyPkmn", 0u }, { "stack", 0x03AEu } } },
+            { "hideoutGiovanni", new Dictionary<string, uint> { { "opponentName", 0x958E8886 }, { "mapIndex", 202 }, { "enemyPkmn", 0u }, { "stack", 0x03AEu } } },
             { "silphGiovanni", new Dictionary<string, uint> { { "opponentName", 0x958E8886 }, { "mapIndex", 0xEBu }, { "enemyPkmn", 0u }, { "stack", 0x03AEu } } },
             { "gym1", new Dictionary<string, uint> { { "opponentName", 0x828E9181 }, { "enemyPkmn", 0u }, { "stack", 0x03AEu } } },
             { "gym2", new Dictionary<string, uint> { { "opponentName", 0x9392888C }, { "enemyPkmn", 0u }, { "stack", 0x03AEu } } },

--- a/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
+++ b/LiveSplit.PkmnRed/LiveSplit.PkmnRed.asl
@@ -157,7 +157,11 @@ update {
 }
 
 start {
-    return vars.watchers["cursorIndex"].Current == 0 && (vars.watchers["input"].Current & 0x80) == 0 && vars.watchers["playerID"].Current == 0 && vars.watchers["stack"].Current == 0x5B91;
+    return vars.watchers["cursorIndex"].Current == 0 && vars.watchers["playerID"].Current == 0 && vars.watchers["stack"].Current == 0x5B91;
+}
+
+reset {
+    return vars.watchers["cursorIndex"].Current == 1 && vars.watchers["playerID"].Current == 0 && vars.watchers["stack"].Current == 0x5B91;
 }
 
 split {


### PR DESCRIPTION
- Add the hideout gio split for Classic (does not affect other categories)
- Turn off 2 splits by defaults that most people don't use
- Add reset when setting options